### PR TITLE
Update php-intercom to 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - php: 5.6
       env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.2
 
 before_script:
   - phpenv rehash

--- a/code/Intercom.php
+++ b/code/Intercom.php
@@ -3,7 +3,7 @@
 namespace Sminnee\SilverStripeIntercom;
 
 use LogicException;
-use Intercom\IntercomBasicAuthClient;
+use Intercom\IntercomClient;
 use SS_List;
 use Member;
 use Config;
@@ -15,28 +15,28 @@ use Injector;
 class Intercom
 {
 
-	private $apiKey;
+	private $personalAccessToken;
 	private $appId;
 	private $client;
 
 	function __construct() {
-		if(defined('INTERCOM_API_KEY')) {
-			$this->apiKey = INTERCOM_API_KEY;
+		if(defined('INTERCOM_PERSONAL_ACCESS_TOKEN')) {
+			$this->personalAccessToken = INTERCOM_PERSONAL_ACCESS_TOKEN;
 		}
 		if(defined('INTERCOM_APP_ID')) {
 			$this->appId = INTERCOM_APP_ID;
 		}
 	}
 
-	function getApiKey() {
-		if(!$this->apiKey) {
-			throw new LogicException("Intercom API key not set! Define INTERCOM_API_KEY or use Injector to set ApiKey");
+	function getPersonalAccessToken() {
+		if(!$this->personalAccessToken) {
+			throw new LogicException("Intercom Personal Access Token not set! Define INTERCOM_PERSONAL_ACCESS_TOKEN or use Injector to set Personal Access Token");
 		}
-		return $this->apiKey;
+		return $this->personalAccessToken;
 	}
 
-	function setApiKey($apiKey) {
-		$this->apiKey = $apiKey;
+	function setPersonalAccessToken($token) {
+		$this->personalAccessToken = $token;
 	}
 
 	function getAppId() {
@@ -45,18 +45,13 @@ class Intercom
 		}
 		return $this->appId;
 	}
-
 	function setAppId($appId) {
 		$this->appId = $appId;
 	}
 
-
 	public function getClient() {
 		if(!$this->client) {
-			$this->client = IntercomBasicAuthClient::factory(array(
-			    'app_id' => $this->getAppId(),
-			    'api_key' => $this->getApiKey()
-			));
+			$this->client = new IntercomClient($this->getPersonalAccessToken(), null);
 		}
 		return $this->client;
 	}
@@ -121,9 +116,9 @@ class Intercom
 			];
 		}
 
-		$result = $this->getClient()->bulkUsers(['items' => $items]);
+		$result = $this->getClient()->bulk->users(['items' => $items]);
 
-		return $this->getBulkJob($result->get('id'));
+		return $this->getBulkJob($result->id);
 	}
 
 
@@ -162,6 +157,6 @@ class Intercom
 			$payload['metadata'] = $eventData;
 		}
 
-		$this->getClient()->createEvent($payload);
+		$this->getClient()->events->create($payload);
 	}
 }

--- a/code/IntercomBulkJob.php
+++ b/code/IntercomBulkJob.php
@@ -2,10 +2,6 @@
 
 namespace Sminnee\SilverStripeIntercom;
 
-use LogicException;
-use Intercom\IntercomBasicAuthClient;
-use Member;
-
 /**
  * Reference to a bulk job result
  */
@@ -25,10 +21,10 @@ class IntercomBulkJob
 	}
 
 	function getInfo(){
-		return $this->client->getJob(['id' => $this->id]);
+		return $this->client->get('jobs/' . $this->id, null);
 	}
 
 	function getErrors(){
-		return $this->client->getJobErrors(['id' => $this->id]);
+		return $this->client->get('jobs/' . $this->id . '/error', null);
 	}
 }

--- a/code/IntercomFormExtension.php
+++ b/code/IntercomFormExtension.php
@@ -207,10 +207,10 @@ class IntercomFormExtension extends DataExtension {
 				$noteData .= '</ul>';
 
 				try {
-					$intercom->getClient()->createNote([
+					$intercom->getClient()->notes->create([
 						'body' => $noteData,
 						'user' => ['id' => $lead['id']]
-					]);	
+					]);
 				}
 				catch (Exception $e) {
 					SS_Log::log("Could not create note: {$e->getMessage()}", SS_Log::WARN);

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "SilverStripe integration with Intercom.io",
     "type": "silverstripe-module",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "silverstripe/framework": "^3.1",
-        "intercom/intercom-php": "^1.3"
+        "intercom/intercom-php": "^3.1"
     },
     "license": "BSD-3-Clause",
     "authors": [

--- a/readme.md
+++ b/readme.md
@@ -4,13 +4,12 @@
 
 This module provides SilverStripe integration for [Intercom](https://www.intercom.io/).
 
-and help others make use of your modules.
-
 ## Requirements
  * SilverStripe Framework 3.1 or higher (4.0 untested). Works nicely with the CMS but it isn't required.
+ * PHP >=5.6.0
 
 ## Installation
-Install the module with composer, just like all your favourite module!
+Install the module with composer, just like all your favourite modules!
 
 ```
 composer require sminnee/silverstripe-intercom
@@ -29,14 +28,14 @@ The module will make use of the following global constants in your `_ss_environm
 set these up
 
  * `INTERCOM_APP_ID`: The "App ID" from Intercom's integration settings. Required.
- * `INTERCOM_API_KEY`: The "API key" from Intercom's integration settings. Required.
+ * `INTERCOM_PERSONAL_ACCESS_TOKEN`: The "Personal Access Token" from Intercom's integration settings. Required.
  * `INTERCOM_SECRET_KEY`: The secret key given by Intercom's Secure Mode. Optional, but highly recommended.
 
 Note that if you disclose your secret key to anyone, they could impersonate users of your app and chat to 
 your support team, so keep it secure! The App ID is less sensitive as it is in the HTML source of your 
 site.
 
-I recommend that you provide enable the "Test Version" of Intercom. This will give you a second App ID that
+I recommend that you enable the "Test Version" of Intercom. This will give you a second App ID that
 you should use on your test and development environments.
 
 Your application can customise the information send with the following properties
@@ -104,7 +103,7 @@ Sometimes, it's not enough to wait until users log in to have their Intercom dat
 you want to use Intercom to send emails you may want to update the Intercom database before the first email
 is sent.
 
-For this purpose, you can set `dev/tasks/IntercomBulkLoadTask` to run no a cronjob. By default it will
+For this purpose, you can set `dev/tasks/IntercomBulkLoadTask` to run on a cronjob. By default it will
 synchronise all Member objects. If you wish to synchornise a reduced list of Members, you can set the
 `user_list` config option on the Intercom class. This should be of the form `%$ServiceName`, where ServiceName
 is the name of an Injector service.


### PR DESCRIPTION
This will update the version of [intercom/intercom-php](https://github.com/intercom/intercom-php) to 3.1.0, which has a simpler interface, and also update the code to use Personal Access Tokens instead of API keys, as these will be [deprecated in January](https://developers.intercom.com/blog/announcement-upcoming-deprecation-of-api-keys).

Notes 
- bumps up the PHP version to >=5.6, and the Guzzle version to ~6.0.
- minor `readme.md` text fixes