### PR TITLE
NEW: Add always_anonymous config option

### DIFF
--- a/code/IntercomScriptTags.php
+++ b/code/IntercomScriptTags.php
@@ -32,11 +32,15 @@ class IntercomScriptTags extends ViewableData
             return false;
         }
 
+        if ($this->config()->always_anonymous) {
+            return true;
+        }
+
         if (!$member) {
             $member = Security::getCurrentUser();
         }
 
-        if (!$this->config()->anonymous_access && !$member) {
+        if (!$this->config()->anonymous_access && !$this->config()->always_anonymous && !$member) {
             return false;
         }
 
@@ -61,7 +65,10 @@ class IntercomScriptTags extends ViewableData
             'app_id' => Intercom::getSetting('INTERCOM_APP_ID'),
         ];
 
-        if (!$member) {
+        // always_anonymous prevents the use of $member
+        if ($this->config()->always_anonymous) {
+            $member = null;
+        } elseif (!$member) {
             $member = Security::getCurrentUser();
         }
 

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,8 @@ SilverStripe\Intercom\IntercomScriptTags:
 
 - `anonymous_access`: If true, then the integration code will be supplied even for anonmyous visitors.
    This is used for Intercom Acquire.
+- `always_anonymous`: If true, then the integration code will never be populated with the details of the current user. Allows better caching.
+   This is used for Intercom Acquire.
 - `company_property`: The property on a member that points to their organisation
 - `company_fields`: A map of Intercom field name to organisation properties to pass through
 - `user_fields`: A map of Intercom field name to member properties to pass through


### PR DESCRIPTION
This means that integration code never uses the current member and can
be more aggressively cached.

Fixes https://github.com/silverstripe/silverstripe-intercom/issues/19